### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     name: Python ${{ matrix.python-version }}-x64
     runs-on: ubuntu-latest
     steps:
@@ -29,11 +29,11 @@ jobs:
           PYUNITY_INTERACTIVE: 0
         run: pytest
       - name: Run mypy
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: |
           mypy -p pyunity
       - name: Run stubtest
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         env:
           PYUNITY_CHANGE_MODULE: 0
         run: |
@@ -41,10 +41,10 @@ jobs:
             --ignore-unused-allowlist --allowlist .github/stubtest-ignore.txt \
             pyunity
       - name: Generate report
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: coverage xml
       - name: Upload report
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.11"
         architecture: x64
     - name: Install dependencies
       run: python -m pip install -r .github/build_requirements.txt
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         arch: ["x86_64", "i686", "aarch64"]
     runs-on: ubuntu-latest
     needs: compile

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.11"
         architecture: x64
     - name: Install dependencies
       run: python -m pip install -r .github/build_requirements.txt
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: macos-latest
     needs: compile
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.11"
         architecture: x64
     - name: Install dependencies
       run: python -m pip install -r .github/build_requirements.txt
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         architecture: ["x64"] # Temporarily disable x86 builds
     needs: compile
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.6"
 dependencies = [


### PR DESCRIPTION
With Python 3.12 coming soon, this will add Python 3.11 support. Should be minimal since PyUnity doesn't have any version-specific code.